### PR TITLE
Fixed worker init

### DIFF
--- a/example/echo/.rr.yaml
+++ b/example/echo/.rr.yaml
@@ -1,3 +1,4 @@
+version: "2.7"
 rpc:
   listen: "tcp://127.0.0.1:6001"
 

--- a/example/echo/worker.php
+++ b/example/echo/worker.php
@@ -5,12 +5,13 @@
  */
 
 use Service\EchoInterface;
+use Spiral\RoadRunner\GRPC\Invoker;
 use Spiral\RoadRunner\GRPC\Server;
 use Spiral\RoadRunner\Worker;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$server = new Server(null, [
+$server = new Server(new Invoker(), [
     'debug' => false, // optional (default: false)
 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        |  None
| Docs PR       | spiral/docs#... No

- The version must be given for current RR release
-  Server do not accept `null` anymore