### PR TITLE
feat: Add support for "google/common-protos" v4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "google/common-protos": "^3.1",
+        "google/common-protos": "^3.1|^4.0",
         "google/protobuf": "^3.7",
         "spiral/roadrunner-worker": "^3.0",
         "spiral/goridge": "^4.0",


### PR DESCRIPTION
Updated the package to support both "google/common-protos" version ^3.1 and ^4.0. This provides users with the flexibility to choose between the two major releases while ensuring backward compatibility.

| Q             | A
| ------------- | ---
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| Issues        | https://github.com/roadrunner-php/issues/issues/25

