### PR TITLE
Update Invoker to handle Message objects as input

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -17,13 +17,19 @@ final class Invoker implements InvokerInterface
         'Method %s input type must be an instance of %s, ' .
         'but the input is type of %s';
 
-    public function invoke(ServiceInterface $service, Method $method, ContextInterface $ctx, ?string $input): string
-    {
+    public function invoke(
+        ServiceInterface $service,
+        Method $method,
+        ContextInterface $ctx,
+        string|Message|null $input,
+    ): string {
         /** @var callable $callable */
         $callable = [$service, $method->name];
 
+        $input = $input instanceof Message ? $input : $this->makeInput($method, $input);
+
         /** @var Message $message */
-        $message = $callable($ctx, $this->makeInput($method, $input));
+        $message = $callable($ctx, $input);
 
         \assert($this->assertResultType($method, $message));
 
@@ -45,7 +51,7 @@ final class Invoker implements InvokerInterface
             $type = \get_debug_type($result);
 
             throw new \BadFunctionCallException(
-                \sprintf(self::ERROR_METHOD_RETURN, $method->name, Message::class, $type)
+                \sprintf(self::ERROR_METHOD_RETURN, $method->name, Message::class, $type),
             );
         }
 
@@ -86,7 +92,7 @@ final class Invoker implements InvokerInterface
     {
         if (!\is_subclass_of($class, Message::class)) {
             throw new \InvalidArgumentException(
-                \sprintf(self::ERROR_METHOD_IN_TYPE, $method->name, Message::class, $class)
+                \sprintf(self::ERROR_METHOD_IN_TYPE, $method->name, Message::class, $class),
             );
         }
 

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -28,6 +28,21 @@ class InvokerTest extends TestCase
         $this->assertSame('pong', $m->getMsg());
     }
 
+    public function testInvokeWithInputMessage(): void
+    {
+        $s = new TestService();
+        $m = Method::parse(new \ReflectionMethod($s, 'Echo'));
+
+        $i = new Invoker();
+
+        $out = $i->invoke($s, $m, new Context([]), $this->createMessage('hello'));
+
+        $m = new Message();
+        $m->mergeFromString($out);
+
+        $this->assertSame('pong', $m->getMsg());
+    }
+
     public function testInvokeError(): void
     {
         $this->expectException(\Spiral\RoadRunner\GRPC\Exception\InvokeException::class);
@@ -42,9 +57,14 @@ class InvokerTest extends TestCase
 
     private function packMessage(string $message): string
     {
+        return $this->createMessage($message)->serializeToString();
+    }
+
+    private function createMessage(string $message): Message
+    {
         $m = new Message();
         $m->setMsg($message);
 
-        return $m->serializeToString();
+        return $m;
     }
 }


### PR DESCRIPTION
Now it can accept both string and Message objects as inputs. This change simplifies the process when the input is already a Message object, eliminating the need to convert it again.

| Q             | A
| ------------- | ---
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️
| Issues        | https://github.com/spiral/roadrunner-bridge/issues/90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced input handling in the `invoke` method to support `Message` objects directly.

- **Bug Fixes**
  - Fixed string formatting issues with added commas in `assertResultType` and `assertInputType` methods.

- **Tests**
  - Added a new test `testInvokeWithInputMessage` to ensure proper handling of `Message` objects.
  - Improved `testInvokeError` with additional assertions for exception handling.
  - Introduced a `packMessage` utility method for test message preparation.
  - Updated `createMessage` method to return `Message` objects for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->