### PR TITLE
Remove PHP versions from GitHub Actions, fix the documentation link

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - '*.*'
   pull_request: null
 
@@ -13,7 +12,5 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1', '8.2']
       stability: >-
         ['prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - '*.*'
   pull_request: null
 
@@ -13,5 +12,3 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1']

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ application.
 
 ## Documentation
 
-You can find more information about RoadRunner GRPC plugin in the [official documentation](https://roadrunner.dev/docs/plugins-grpc).
+You can find more information about RoadRunner GRPC plugin in the [official documentation](https://docs.roadrunner.dev/plugins/grpc).
 
 ## Example
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "homepage": "https://roadrunner.dev/",
     "support": {
-        "docs": "https://roadrunner.dev/docs",
+        "docs": "https://docs.roadrunner.dev",
         "issues": "https://github.com/roadrunner-server/roadrunner/issues",
         "forum": "https://forum.roadrunner.dev/",
         "chat": "https://discord.gg/V6EK4he"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `master` branch restriction for pushes in GitHub workflows.
	- Adjusted the PHP version configuration in workflow files.
- **Documentation**
	- Updated a URL in the README.md documentation section to reflect the correct location for gRPC plugins documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->