### PR TITLE
Add PreInvoke and PostInvoke events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,10 @@
         "ext-json": "*",
         "google/common-protos": "^3.1|^4.0",
         "google/protobuf": "^3.7",
-        "spiral/roadrunner-worker": "^3.0",
+        "psr/event-dispatcher": "^1.0",
         "spiral/goridge": "^4.0",
-        "spiral/roadrunner": "^2023.1 || ^2024.1"
+        "spiral/roadrunner": "^2023.1 || ^2024.1",
+        "spiral/roadrunner-worker": "^3.0"
     },
     "require-dev": {
         "jetbrains/phpstorm-attributes": "^1.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -20,6 +20,7 @@
         <InvalidAttribute errorLevel="suppress" />
         <UndefinedAttributeClass errorLevel="suppress" />
         <DocblockTypeContradiction errorLevel="suppress" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
     <projectFiles>
         <directory name="src" />

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\GRPC\Event;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+class Event implements StoppableEventInterface
+{
+    private bool $propagationStopped = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * Stops the propagation of the event to further event listeners.
+     *
+     * If multiple event listeners are connected to the same event, no
+     * further event listener will be triggered once any trigger calls
+     * stopPropagation().
+     */
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
+    }
+}

--- a/src/Event/PostInvokeEvent.php
+++ b/src/Event/PostInvokeEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\GRPC\Event;
+
+use Google\Protobuf\Internal\Message;
+
+final class PostInvokeEvent extends Event
+{
+    public function __construct(
+        private readonly Message $output,
+    ) {
+    }
+
+    public function getOutput(): Message
+    {
+        return $this->output;
+    }
+}

--- a/src/Event/PreInvokeEvent.php
+++ b/src/Event/PreInvokeEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\GRPC\Event;
+
+use Google\Protobuf\Internal\Message;
+use Spiral\RoadRunner\GRPC\ContextInterface;
+
+final class PreInvokeEvent extends Event
+{
+    public function __construct(
+        private readonly ContextInterface $ctx,
+        private readonly Message $input,
+    ) {
+    }
+
+    public function getContext(): ContextInterface
+    {
+        return $this->ctx;
+    }
+
+    public function getInput(): Message
+    {
+        return $this->input;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | Enchant invoker functionality with PreInvoke and PostInvoke events for a general purpose  <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

<!-- Please, replace this notice by a short description of your feature/bugfix.
This will help people understand your PR and can be used as a start for the documentation. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event dispatching for gRPC service methods, enabling hooks before and after method invocation.
  
- **Bug Fixes**
  - Updated dependencies to replace `"spiral/roadrunner-worker"` with `"psr/event-dispatcher"` for improved event handling.

- **Chores**
  - Suppressed `MissingClassConstType` issue in the `psalm.xml` configuration for cleaner code analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->