### PR TITLE
Reset exception variable in main loop

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -104,6 +104,7 @@ final class Server
         $worker ??= Worker::create();
 
         while (true) {
+            $e = null;
             $request = $worker->waitPayload();
 
             if ($request === null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | closes: https://github.com/roadrunner-php/issues/issues/32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the server to ensure smoother operation by initializing the error variable before the main loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->