### PR TITLE
Propagate response headers with grpc error metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "google/protobuf": "^3.7 || ^4.0",
         "spiral/roadrunner-worker": "^3.0",
         "spiral/goridge": "^4.0",
-        "spiral/roadrunner": "^2023.1 || ^2024.1"
+        "spiral/roadrunner": "^2024.3"
     },
     "require-dev": {
         "jetbrains/phpstorm-attributes": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,11 @@
     "config": {
         "sort-packages": true
     },
+    "extra": {
+        "branch-alias": {
+            "3.x": "3.4.x-dev"
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -77,11 +77,6 @@
     "config": {
         "sort-packages": true
     },
-    "extra": {
-        "branch-alias": {
-            "3.x": "3.4.x-dev"
-        }
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@765dcbfe43002e52e4808b65561842784fe7bcc7"/>
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0"/>

--- a/src/Internal/CallContext.php
+++ b/src/Internal/CallContext.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\GRPC\Internal;
+
+use Spiral\RoadRunner\GRPC\ServiceInterface;
+
+/**
+ * @internal
+ * @psalm-internal Spiral\RoadRunner\GRPC
+ */
+final class CallContext
+{
+    /**
+     * @param class-string<ServiceInterface> $service
+     * @param non-empty-string $method
+     * @param array<string, array<string>> $context
+     */
+    public function __construct(
+        public string $service,
+        public string $method,
+        public array $context,
+    ) {
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public static function decode(string $payload): self
+    {
+        $data = Json::decode($payload);
+
+        return new self(
+            service: $data['service'],
+            method: $data['method'],
+            context: $data['context'],
+        );
+    }
+}

--- a/src/Internal/CallContext.php
+++ b/src/Internal/CallContext.php
@@ -18,9 +18,9 @@ final class CallContext
      * @param array<string, array<string>> $context
      */
     public function __construct(
-        public string $service,
-        public string $method,
-        public array $context,
+        public readonly string $service,
+        public readonly string $method,
+        public readonly array $context,
     ) {
     }
 

--- a/src/Internal/CallContext.php
+++ b/src/Internal/CallContext.php
@@ -29,6 +29,13 @@ final class CallContext
      */
     public static function decode(string $payload): self
     {
+        /**
+         * @psalm-var array{
+         *  service: class-string<ServiceInterface>,
+         *  method:  non-empty-string,
+         *  context: array<string, array<string>>
+         * } $data
+         */
         $data = Json::decode($payload);
 
         return new self(

--- a/src/Internal/CallContext.php
+++ b/src/Internal/CallContext.php
@@ -21,8 +21,7 @@ final class CallContext
         public readonly string $service,
         public readonly string $method,
         public readonly array $context,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws \JsonException

--- a/src/ResponseTrailers.php
+++ b/src/ResponseTrailers.php
@@ -39,10 +39,9 @@ final class ResponseTrailers implements \IteratorAggregate, \Countable
 
     /**
      * @param THeaderKey $key
-     * @param string|null $default
      * @return THeaderValue|null
      */
-    public function get(string $key, string $default = null): ?string
+    public function get(string $key, ?string $default = null): ?string
     {
         return $this->trailers[$key] ?? $default;
     }

--- a/src/ResponseTrailers.php
+++ b/src/ResponseTrailers.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\GRPC;
+
+use Spiral\RoadRunner\GRPC\Internal\Json;
+
+/**
+ * @psalm-type THeaderKey = non-empty-string
+ * @psalm-type THeaderValue = string
+ * @implements \IteratorAggregate<THeaderKey, string>
+ */
+final class ResponseTrailers implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var array<THeaderKey, THeaderValue>
+     */
+    private array $trailers = [];
+
+    /**
+     * @param iterable<THeaderKey, THeaderValue> $trailers
+     */
+    public function __construct(iterable $trailers = [])
+    {
+        foreach ($trailers as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
+     * @param THeaderKey $key
+     * @param THeaderValue $value
+     */
+    public function set(string $key, string $value): void
+    {
+        $this->trailers[$key] = $value;
+    }
+
+    /**
+     * @param THeaderKey $key
+     * @param string|null $default
+     * @return THeaderValue|null
+     */
+    public function get(string $key, string $default = null): ?string
+    {
+        return $this->trailers[$key] ?? $default;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->trailers);
+    }
+
+    public function count(): int
+    {
+        return \count($this->trailers);
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public function packTrailers(): string
+    {
+        // If an empty array is serialized, it is cast to the string "[]"
+        // instead of object string "{}"
+        if ($this->trailers === []) {
+            return '{}';
+        }
+
+        return Json::encode($this->trailers);
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -88,23 +88,27 @@ final class Server
 
                 $response = $this->invoke($call->service, $call->method, $context, $request->body);
 
+                $headers = array_filter([
+                    'headers' => $responseHeaders->count() ? $responseHeaders->packHeaders() : null,
+                    'trailers' => $responseTrailers->count() ? $responseTrailers->packTrailers() : null,
+                ]);
+
                 $this->workerSend(
                     worker: $worker,
                     body: $response,
-                    headers: Json::encode([
-                        'headers' => $responseHeaders->packHeaders(),
-                        'trailers' => $responseTrailers->packTrailers(),
-                    ]),
+                    headers: !empty($headers) ? Json::encode($headers) : '{}',
                 );
             } catch (GRPCExceptionInterface $e) {
+                $headers = array_filter([
+                    'error' => $this->createGrpcError($e),
+                    'headers' => $responseHeaders->count() ? $responseHeaders->packHeaders() : null,
+                    'trailers' => $responseTrailers->count() ? $responseTrailers->packTrailers() : null,
+                ]);
+
                 $this->workerSend(
                     worker: $worker,
                     body: '',
-                    headers: Json::encode([
-                        'error' => $this->createGrpcError($e),
-                        'headers' => $responseHeaders->packHeaders(),
-                        'trailers' => $responseTrailers->packTrailers(),
-                    ]),
+                    headers: Json::encode($headers),
                 );
             } catch (\Throwable $e) {
                 $this->workerError($worker, $this->isDebugMode() ? (string) $e : $e->getMessage());

--- a/src/Server.php
+++ b/src/Server.php
@@ -78,12 +78,12 @@ final class Server
             try {
                 $call = CallContext::decode($request->header);
 
-                $context = new Context(array_merge(
+                $context = new Context(\array_merge(
                     $call->context,
                     [
                         ResponseHeaders::class => $responseHeaders,
-                        ResponseTrailers::class => $responseTrailers
-                    ]
+                        ResponseTrailers::class => $responseTrailers,
+                    ],
                 ));
 
                 $response = $this->invoke($call->service, $call->method, $context, $request->body);

--- a/src/Server.php
+++ b/src/Server.php
@@ -88,22 +88,21 @@ final class Server
 
                 $response = $this->invoke($call->service, $call->method, $context, $request->body);
 
-                $headers = array_filter([
-                    'headers' => $responseHeaders->count() ? $responseHeaders->packHeaders() : null,
-                    'trailers' => $responseTrailers->count() ? $responseTrailers->packTrailers() : null,
-                ]);
+                $headers = [];
+                $responseHeaders->count() === 0 or $headers['headers'] = $responseHeaders->packHeaders();
+                $responseTrailers->count() === 0 or $headers['trailers'] = $responseTrailers->packTrailers();
 
                 $this->workerSend(
                     worker: $worker,
                     body: $response,
-                    headers: !empty($headers) ? Json::encode($headers) : '{}',
+                    headers: $headers === [] ? '{}' : Json::encode($headers),
                 );
             } catch (GRPCExceptionInterface $e) {
-                $headers = array_filter([
+                $headers = [
                     'error' => $this->createGrpcError($e),
-                    'headers' => $responseHeaders->count() ? $responseHeaders->packHeaders() : null,
-                    'trailers' => $responseTrailers->count() ? $responseTrailers->packTrailers() : null,
-                ]);
+                ];
+                $responseHeaders->count() === 0 or $headers['headers'] = $responseHeaders->packHeaders();
+                $responseTrailers->count() === 0 or $headers['trailers'] = $responseTrailers->packTrailers();
 
                 $this->workerSend(
                     worker: $worker,

--- a/src/Server.php
+++ b/src/Server.php
@@ -73,19 +73,28 @@ final class Server
             }
 
             $responseHeaders = new ResponseHeaders();
+            $responseTrailers = new ResponseTrailers();
 
             try {
                 $call = CallContext::decode($request->header);
 
-                $context = (new Context($call->context))
-                    ->withValue(ResponseHeaders::class, $responseHeaders);
+                $context = new Context(array_merge(
+                    $call->context,
+                    [
+                        ResponseHeaders::class => $responseHeaders,
+                        ResponseTrailers::class => $responseTrailers
+                    ]
+                ));
 
                 $response = $this->invoke($call->service, $call->method, $context, $request->body);
 
                 $this->workerSend(
                     worker: $worker,
                     body: $response,
-                    headers: $responseHeaders->packHeaders()
+                    headers: Json::encode([
+                        'headers' => $responseHeaders->packHeaders(),
+                        'trailers' => $responseTrailers->packTrailers(),
+                    ]),
                 );
             } catch (GRPCExceptionInterface $e) {
                 $this->workerSend(
@@ -94,6 +103,7 @@ final class Server
                     headers: Json::encode([
                         'error' => $this->createGrpcError($e),
                         'headers' => $responseHeaders->packHeaders(),
+                        'trailers' => $responseTrailers->packTrailers(),
                     ]),
                 );
             } catch (\Throwable $e) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -10,6 +10,7 @@ use Spiral\RoadRunner\GRPC\Exception\GRPCException;
 use Spiral\RoadRunner\GRPC\Exception\GRPCExceptionInterface;
 use Spiral\RoadRunner\GRPC\Exception\NotFoundException;
 use Spiral\RoadRunner\GRPC\Exception\ServiceException;
+use Spiral\RoadRunner\GRPC\Internal\CallContext;
 use Spiral\RoadRunner\GRPC\Internal\Json;
 use Spiral\RoadRunner\Payload;
 use Spiral\RoadRunner\Worker;
@@ -20,12 +21,6 @@ use Spiral\RoadRunner\WorkerInterface;
  *
  * @psalm-type ServerOptions = array{
  *  debug?: bool
- * }
- *
- * @psalm-type ContextResponse = array{
- *  service: class-string<ServiceInterface>,
- *  method:  non-empty-string,
- *  context: array<string, array<string>>
  * }
  */
 final class Server
@@ -77,15 +72,30 @@ final class Server
                 return;
             }
 
+            $responseHeaders = new ResponseHeaders();
+
             try {
-                /** @var ContextResponse $context */
-                $context = Json::decode($request->header);
+                $call = CallContext::decode($request->header);
 
-                [$answerBody, $answerHeaders] = $this->tick($request->body, $context);
+                $context = (new Context($call->context))
+                    ->withValue(ResponseHeaders::class, $responseHeaders);
 
-                $this->workerSend($worker, $answerBody, $answerHeaders);
+                $response = $this->invoke($call->service, $call->method, $context, $request->body);
+
+                $this->workerSend(
+                    worker: $worker,
+                    body: $response,
+                    headers: $responseHeaders->packHeaders()
+                );
             } catch (GRPCExceptionInterface $e) {
-                $this->workerGrpcError($worker, $e);
+                $this->workerSend(
+                    worker: $worker,
+                    body: '',
+                    headers: Json::encode([
+                        'error' => $this->createGrpcError($e),
+                        'headers' => $responseHeaders->packHeaders(),
+                    ]),
+                );
             } catch (\Throwable $e) {
                 $this->workerError($worker, $this->isDebugMode() ? (string) $e : $e->getMessage());
             } finally {
@@ -112,24 +122,9 @@ final class Server
         return $this->services[$service]->invoke($method, $context, $body);
     }
 
-    /**
-     * @param ContextResponse $data
-     * @return array{0: string, 1: string}
-     * @throws \JsonException
-     * @throws \Throwable
-     */
-    private function tick(string $body, array $data): array
+    private function workerError(WorkerInterface $worker, string $message): void
     {
-        $context = (new Context($data['context']))
-            ->withValue(ResponseHeaders::class, new ResponseHeaders());
-
-        $response = $this->invoke($data['service'], $data['method'], $context, $body);
-
-        /** @var ResponseHeaders|null $responseHeaders */
-        $responseHeaders = $context->getValue(ResponseHeaders::class);
-        $responseHeadersString = $responseHeaders ? $responseHeaders->packHeaders() : '{}';
-
-        return [$response, $responseHeadersString];
+        $worker->error($message);
     }
 
     /**
@@ -140,12 +135,7 @@ final class Server
         $worker->respond(new Payload($body, $headers));
     }
 
-    private function workerError(WorkerInterface $worker, string $message): void
-    {
-        $worker->error($message);
-    }
-
-    private function workerGrpcError(WorkerInterface $worker, GRPCExceptionInterface $e): void
+    private function createGrpcError(GRPCExceptionInterface $e): string
     {
         $status = new Status([
             'code' => $e->getCode(),
@@ -161,13 +151,7 @@ final class Server
             ),
         ]);
 
-        $this->workerSend(
-            $worker,
-            '',
-            Json::encode([
-                'error' => \base64_encode($status->serializeToString()),
-            ]),
-        );
+        return \base64_encode($status->serializeToString());
     }
 
     /**

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -7,6 +7,7 @@ namespace Spiral\RoadRunner\GRPC\Tests;
 use PHPUnit\Framework\TestCase;
 use Spiral\RoadRunner\GRPC\Context;
 use Spiral\RoadRunner\GRPC\ResponseHeaders;
+use Spiral\RoadRunner\GRPC\ResponseTrailers;
 
 class ContextTest extends TestCase
 {
@@ -74,5 +75,25 @@ class ContextTest extends TestCase
         ]);
         $ctx = new Context([ResponseHeaders::class => $outgoingHeaders]);
         $this->assertSame($outgoingHeaders, $ctx->getValue(ResponseHeaders::class));
+    }
+
+    public function testGetOutgoingTrailer(): void
+    {
+        $outgoingTrailers = [
+            'X-Some-Trailer' => 'foobar',
+        ];
+        $ctx = new Context([ResponseTrailers::class => new ResponseTrailers($outgoingTrailers)]);
+
+        $this->assertSame($outgoingTrailers['X-Some-Trailer'], $ctx->getValue(ResponseTrailers::class)->get('X-Some-Trailer'));
+        $this->assertNull($ctx->getValue(ResponseTrailers::class)->get('not-existing'));
+    }
+
+    public function testGetOutgoingTrailers(): void
+    {
+        $outgoingTrailers = new ResponseTrailers([
+            'X-Some-Trailer' => 'foobar',
+        ]);
+        $ctx = new Context([ResponseTrailers::class => $outgoingTrailers]);
+        $this->assertSame($outgoingTrailers, $ctx->getValue(ResponseTrailers::class));
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -7,17 +7,18 @@ namespace Spiral\RoadRunner\GRPC\Tests;
 use Google\Rpc\Status;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Service\DetailsMessageForException;
 use Service\Message;
 use Service\TestInterface;
 use Spiral\Goridge\Frame;
 use Spiral\Goridge\RelayInterface;
 use Spiral\RoadRunner\GRPC\Exception\ServiceException;
+use Spiral\RoadRunner\GRPC\InvokerInterface;
 use Spiral\RoadRunner\GRPC\Server;
 use Spiral\RoadRunner\GRPC\Tests\Stub\TestService;
 use Spiral\RoadRunner\Payload;
 use Spiral\RoadRunner\Worker;
 use Spiral\RoadRunner\WorkerInterface;
-use Spiral\RoadRunner\GRPC\InvokerInterface;
 
 class ServerTest extends TestCase
 {
@@ -141,6 +142,40 @@ class ServerTest extends TestCase
 
         $server->registerService(TestInterface::class, $service);
         $server->serve($worker);
+    }
+
+    public function testInvokeGrpcException(): void
+    {
+        $worker = m::mock(WorkerInterface::class);
+        $worker->shouldReceive('waitPayload')
+            ->times(2)
+            ->andReturn(
+                new Payload(
+                    body: $this->packMessage('withDetailsAndHeaders'),
+                    header: '{"context": {}, "service": "service.Test", "method": "Throw"}',
+                ),
+                null,
+            );
+
+        $worker->shouldReceive('respond')->once()
+            ->withArgs(static function (Payload $payload) {
+                $header = \json_decode($payload->header, true);
+
+                $status = new Status();
+                $status->mergeFromString(\base64_decode($header['error']));
+                /** @var DetailsMessageForException $message */
+                $message = $status->getDetails()->offsetGet(0)->unpack();
+
+                $outgoingHeaders = \json_decode($header['headers'], true);
+                $outgoingTrailers = \json_decode($header['trailers'], true);
+
+                return $message instanceof DetailsMessageForException
+                    && $message->getMessage() === 'details message'
+                    && $outgoingHeaders === ['foo' => 'bar']
+                    && $outgoingTrailers === ['baz' => 'bar'];
+            });
+
+        $this->server->serve($worker);
     }
 
     protected function setUp(): void

--- a/tests/Stub/TestService.php
+++ b/tests/Stub/TestService.php
@@ -35,6 +35,17 @@ class TestService implements TestInterface
                 $grpcException = new GRPCException("main exception message", 3, [$detailsMessage]);
 
                 throw $grpcException;
+            case "withDetailsAndHeaders":
+                $ctx->getValue(GRPC\ResponseHeaders::class)->set('foo', 'bar');
+                $ctx->getValue(GRPC\ResponseTrailers::class)->set('baz', 'bar');
+
+                $detailsMessage = new DetailsMessageForException();
+                $detailsMessage->setCode(1);
+                $detailsMessage->setMessage("details message");
+
+                $grpcException = new GRPCException("main exception message", 3, [$detailsMessage]);
+
+                throw $grpcException;
             case "regularException":
                 {
                     throw new \Exception("Just another exception");
@@ -70,6 +81,7 @@ class TestService implements TestInterface
         }
 
         $ctx->getValue(GRPC\ResponseHeaders::class)->set('foo', 'bar');
+        $ctx->getValue(GRPC\ResponseTrailers::class)->set('baz', 'bar');
 
         return $out;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️

This change propagates response headers as part of grpc error response. This is helpful when your server needs to send certain headers (like `X-Correlation-Id`, etc) even in case of Exception.

Update: this change also introduces `ResponseTrailers` which could be used alongside `ResponseHeaders`.  It is expected to send data like this:

```
{
  "error": "base64_encoded_proto",
  "headers": "{\"header_key_1\": \"header_value_1\", \"header_key_2\": \"header_value_2\"}",
  "trailers": "{\"trailer_key_1\": \"trailer_value_1\", \"trailer_key_2\": \"trailer_value_2\"}"
}
```

And if it's a successful response, then binary payload headers part will also accordingly change from this:

```
{"header_key_1": "header_value_1", "header_key_2": "header_value_2"}
```

to this:
```
{
  "headers": "{\"header_key_1\": \"header_value_1\", \"header_key_2\": \"header_value_2\"}",
  "trailers": "{\"trailer_key_1\": \"trailer_value_1\", \"trailer_key_2\": \"trailer_value_2\"}"
}
```

ref: https://github.com/roadrunner-server/roadrunner/issues/2006

@rustatian:
Note, this PR should be synced with RR 2024.3 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `CallContext` for enhanced request header processing.
	- Added `ResponseTrailers` class for managing response headers and trailers.
  
- **Improvements**
	- Streamlined GRPC request and response handling.
	- Enhanced error reporting and processing mechanisms.
  
- **Testing Enhancements**
	- Added tests for `ResponseTrailers` functionality.
	- Introduced test for handling gRPC exceptions in the server.
  
- **Dependency Updates**
	- Updated version constraint for `spiral/roadrunner` package to allow versions from `2024.3` and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->