### PR TITLE
Remove PHP 8.4 deprecation notice

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -99,7 +99,7 @@ final class Server
     /**
      * Serve GRPC over given RoadRunner worker.
      */
-    public function serve(WorkerInterface $worker = null, callable $finalize = null): void
+    public function serve(?WorkerInterface $worker = null, ?callable $finalize = null): void
     {
         $worker ??= Worker::create();
 


### PR DESCRIPTION
Deprecated: Spiral\RoadRunner\GRPC\Server::serve(): Implicitly marking parameter $worker as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/app/vendor/spiral/roadrunner-grpc/src/Server.php on line 102

Deprecated: Spiral\RoadRunner\GRPC\Server::serve(): Implicitly marking parameter $finalize as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/apps/vendor/spiral/roadrunner-grpc/src/Server.php on line 102

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `serve` method to allow nullable parameters for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->