### PR TITLE
Implicitly marking parameter $previous as nullable is deprecated

### DIFF
--- a/src/Exception/GRPCException.php
+++ b/src/Exception/GRPCException.php
@@ -30,7 +30,7 @@ class GRPCException extends \RuntimeException implements MutableGRPCExceptionInt
         string $message = '',
         ?int $code = null,
         private array $details = [],
-        \Throwable $previous = null,
+        ?\Throwable $previous = null,
     ) {
         parent::__construct($message, $code ?? static::CODE, $previous);
     }
@@ -44,7 +44,7 @@ class GRPCException extends \RuntimeException implements MutableGRPCExceptionInt
         string $message,
         #[ExpectedValues(valuesFromClass: StatusCode::class)]
         int $code = self::CODE,
-        \Throwable $previous = null,
+        ?\Throwable $previous = null,
         array $details = [],
     ): self {
         return new static($message, $code, $details, $previous);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Issue         | https://github.com/roadrunner-php/issues/issues/39

PHP 8.4
Deprecated: Spiral\RoadRunner\GRPC\Exception\GRPCException::create(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated exception handling to improve type safety by making the `$previous` parameter explicitly nullable in the `GRPCException` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->