### PR TITLE
Implicitly marking parameter $default as nullable is deprecated

### DIFF
--- a/src/ResponseHeaders.php
+++ b/src/ResponseHeaders.php
@@ -42,7 +42,7 @@ final class ResponseHeaders implements \IteratorAggregate, \Countable
      * @param string|null $default
      * @return THeaderValue|null
      */
-    public function get(string $key, string $default = null): ?string
+    public function get(string $key, ?string $default = null): ?string
     {
         return $this->headers[$key] ?? $default;
     }


### PR DESCRIPTION
PHP 8.4
Deprecated: Spiral\RoadRunner\GRPC\ResponseHeaders::get(): Implicitly marking parameter $default as nullable is deprecated, the explicit nullable type must be used instead

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Issue       | https://github.com/roadrunner-php/issues/issues/39



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type handling for response headers method, allowing more flexible default value management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->